### PR TITLE
Split connect_midi_input method of MidiInputHandler into MidiInputConnector trait

### DIFF
--- a/src/devices/korg_kaoss_dj/input.rs
+++ b/src/devices/korg_kaoss_dj/input.rs
@@ -7,8 +7,8 @@ use num_traits::{FromPrimitive as _, ToPrimitive as _};
 use super::Deck;
 use crate::{
     ButtonInput, CenterSliderInput, ControlIndex, ControlInput, ControlInputEvent, EmitInputEvent,
-    MidiDeviceDescriptor, MidiInputHandler, SliderEncoderInput, SliderInput, StepEncoderInput,
-    TimeStamp,
+    MidiDeviceDescriptor, MidiInputConnector, MidiInputHandler, SliderEncoderInput, SliderInput,
+    StepEncoderInput, TimeStamp,
 };
 
 fn u7_to_button(input: u8) -> ButtonInput {
@@ -524,16 +524,6 @@ impl<E> MidiInputHandler for InputGateway<E>
 where
     E: EmitInputEvent<Input> + Send,
 {
-    fn connect_midi_input_port(
-        &mut self,
-        _device_descriptor: &MidiDeviceDescriptor,
-        client_name: &str,
-        port_name: &str,
-        _port: &midir::MidiInputPort,
-    ) {
-        log::debug!("Device \"{client_name}\" is connected to port \"{port_name}\"");
-    }
-
     fn handle_midi_input(&mut self, ts: TimeStamp, input: &[u8]) {
         let Some(input) = Input::try_from_midi_message(input) else {
             log::debug!("[{ts}] Unhandled MIDI input message: {input:x?}");
@@ -542,6 +532,21 @@ where
         let event = InputEvent { ts, input };
         log::debug!("Emitting {event:?}");
         self.emit_input_event.emit_input_event(event);
+    }
+}
+
+impl<E> MidiInputConnector for InputGateway<E>
+where
+    E: Send,
+{
+    fn connect_midi_input_port(
+        &mut self,
+        _device_descriptor: &MidiDeviceDescriptor,
+        client_name: &str,
+        port_name: &str,
+        _port: &midir::MidiInputPort,
+    ) {
+        log::debug!("Device \"{client_name}\" is connected to port \"{port_name}\"");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,5 +138,5 @@ mod midi;
 #[cfg(feature = "midi")]
 pub use self::midi::{
     GenericMidiDevice, GenericMidiDeviceManager, MidiDevice, MidiDeviceDescriptor,
-    MidiDeviceManager, MidiInputHandler, MidiPortError,
+    MidiDeviceManager, MidiInputConnector, MidiInputHandler, MidiPortError, MidirDevice,
 };


### PR DESCRIPTION
Motivation:
I want to use a custom midi implementation (using wasm) but want to re-use some code but the `MidiInputHandler` depends on `midir` because of the  `connect_midi_input` method.
Splitting this into two traits allows a bit more flexibility.